### PR TITLE
Fix container build

### DIFF
--- a/Dockerfile-db
+++ b/Dockerfile-db
@@ -1,4 +1,4 @@
-FROM mariadb:latest
+FROM mariadb:10.6
 ENV MYSQL_ROOT_PASSWORD=root
 ENV MYSQL_USER=maptool
 ENV MYSQL_PASSWORD=maptool

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,7 @@
 FROM node:15
 WORKDIR /root/app
 COPY package.json /root/app
+COPY package-lock.json /root/app
 RUN npm install
 RUN npm install -g nodemon
 COPY . /root/app


### PR DESCRIPTION
Node packages and the mariadb container have moved on, so using latest doesn't work.

The package lock is available and just wasn't copied into the container.

Mariadb changed the default behaviour of timestamp fields in 10.10, and the latest available 10.x release before that on dockerhup is 10.6 so I've pinned it to that.