### PR TITLE
Add static routes and serve a click redirector

### DIFF
--- a/src/resources/static/click.html
+++ b/src/resources/static/click.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <script>
+window.onload = function() {
+  const urlParams = new URLSearchParams(location.search);
+  const uri = urlParams.get("uri");
+  if (!uri) {
+    return;
+  }
+  if (!uri.startsWith("rptools-maptool+")) {
+    return;
+  }
+  location.replace(uri);
+}
+    </script>
+  </head>
+</html>
+

--- a/src/server/routes/RoutesManagerImpl.ts
+++ b/src/server/routes/RoutesManagerImpl.ts
@@ -14,12 +14,13 @@
  */
 
 import { RouteHandler } from './RouteHandler';
-import { Express } from 'express';
+import { default as express, Express } from 'express';
 import { inject, injectable } from 'inversify';
 import { RoutesManager } from './RoutesManager';
 import { Logger } from '../../util/Logger';
 import { DEPENDENCY_TYPES } from '../../inversify/inversify-types';
 import { LoggerFactory } from '../../util/LoggerFactory';
+import path from 'path';
 
 @injectable()
 export class RoutesManagerImpl implements RoutesManager {
@@ -38,6 +39,8 @@ export class RoutesManagerImpl implements RoutesManager {
     this.routes.forEach((r) => {
       r.addRoutes(expressApp);
     });
+    this.logger.info("Registering static routes");
+    expressApp.use(express.static(path.join(__dirname, '../../resources/static')));
   };
 
   registerRoutes = (routes: RouteHandler): void => {


### PR DESCRIPTION
Starting MapTool via URI handler requires a URI that starts with rptools-maptool, but chat applications won't automatically turn URIs of that form into links, and some apps (such as Discord) don't support manually creating links.

It's probably safe to assume that users will have a web browser installed though and web browsers can redirect to other URIs (probably with some prompt to allow that page to redirect in future) so if the registry server hosts such a page then MapTool can create links to that page for users to paste into chat.

@cwisniew suggested adding the redirector to the registry server, so I figured I'd learn enough about how the registry server is implemented to do it myself.